### PR TITLE
disable helix auto pairs

### DIFF
--- a/modules/programs/helix.nix
+++ b/modules/programs/helix.nix
@@ -13,6 +13,8 @@
   my.programs.zsh.initExtra = ''
     export EDITOR="${config.my.home.sessionVariables.EDITOR}"
   '';
+  
+
  my.programs.helix = with pkgs; let
     py-lsp = "${python311Packages.python-lsp-server.overrideAttrs(old: {
       buildInputs = (
@@ -24,6 +26,7 @@
     go-lsp = "${gopls}/bin/gopls";
   in {
     enable = true;
+    settings.editor.auto-pairs = false;
     languages = {
       language = [
         ({


### PR DESCRIPTION
Closes #58. 

Not possible to do currently (see https://github.com/helix-editor/helix/issues/4035)
so autopairs are disabled for now
